### PR TITLE
Move addBreadcrumb into effect in useBreadcrumb

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -78,8 +78,8 @@ export const useBreadcrumb = ({ label, url }: Omit<BreadcrumbItem, 'id'>) => {
     url,
   ]);
 
-  addBreadcrumb(crumb);
   React.useEffect(() => {
+    addBreadcrumb(crumb);
     return () => removeBreadcrumb(crumb);
   }, [addBreadcrumb, removeBreadcrumb, crumb]);
 };


### PR DESCRIPTION
This addresses an issue where breadcrumbs can be duplicated when the component calling the `useBreadcrumb` hook is cloned, e.g., using `React.cloneElement`. I found that moving the call to `addBreadcrumb` into the effect avoids the duplication. My suspicion is that component function is rerun during cloning, but the effect is not, which causes the cleanup call to `removeBreadcrumb` to get out-of-sync.

I tried writing a Jest unit test for this behavior in my [minimal working example][mwe], but the duplication did not happen when using jsdom. I'm not sure why, but for what it's worth, it's not a perfect emulation of a browser. E.g., perhaps timing is important.

Fixes #2 

[mwe]: https://github.com/chrisbouchard/react-breadcrumbs-duplicated-crumbs-mwe